### PR TITLE
Return transformed query result from get_gocams_by_geneproduct_id

### DIFF
--- a/app/routers/pathway_widget.py
+++ b/app/routers/pathway_widget.py
@@ -6,6 +6,7 @@ from oaklib.implementations.sparql.sparql_implementation import \
 from oaklib.resource import OntologyResource
 from prefixcommons.curie_util import expand_uri, read_biocontext
 from app.utils.settings import get_sparql_endpoint, get_user_agent
+from app.utils.sparql.sparql_utils import transform_array
 logger = logging.getLogger(__name__)
 
 USER_AGENT = get_user_agent()
@@ -153,10 +154,4 @@ async def get_gocams_by_geneproduct_id(
             % id
         )
     results = si._sparql_query(query)
-    collated_results = []
-    collated = {}
-    for row in results:
-        collated["gocam"] = row["gocam"].get("value")
-        collated["title"] = row["title"].get("value")
-        collated_results.append(collated)
-    return results
+    return transform_array(results)


### PR DESCRIPTION
This allows the `/api/gp/{id}/models` endpoint to return "plain" values like:

```json
  {
    "gocam": "http://model.geneontology.org/5745387b00001770",
    "title": "Zcchc16, zinc finger, CCHC domain containing 16"
  }
```

Instead of:

```json
  {
    "gocam": {
      "type": "uri",
      "value": "http://model.geneontology.org/5745387b00001770"
    },
    "title": {
      "datatype": "http://www.w3.org/2001/XMLSchema#string",
      "type": "literal",
      "value": "Zcchc16, zinc finger, CCHC domain containing 16"
    }
  },
```