### PR TITLE
added support for redirecting http to https

### DIFF
--- a/provision/production/config-stack.yaml.sample
+++ b/provision/production/config-stack.yaml.sample
@@ -22,4 +22,7 @@ stack:
 
       fastapi_host: REPLACE_ME # aes-test-go-fastapi
       fastapi_tag: 0.2.0
+
+      REDIRECT_HTTP: 1
+      redirect_to: REPLACE_ME # aes-test-go-fastapi.geneontology.org
    scripts: [ "stage.yaml", "start_services.yaml" ]

--- a/provision/stage.yaml
+++ b/provision/stage.yaml
@@ -24,8 +24,19 @@
           dest: '{{ stage_dir }}/{{ item.dir }}'
         with_items:
           - { file: 'docker-compose-production.yaml', dir: 'docker-compose.yaml' }
-          - { file: 'httpd-vhosts-prod-fastapi.conf', dir: 'httpd-confs' }
           - { file: 'config.yaml', dir: 'conf' }
+
+      - name: install http conf file
+        template:
+          src: httpd-vhosts-prod-fastapi.conf 
+          dest: '{{ stage_dir }}/httpd-confs/httpd-vhosts-prod-fastapi.conf'
+        when: not REDIRECT_HTTP | bool
+
+      - name: install http redirect file
+        template:
+          src: httpd-vhosts-prod-fastapi-redirect.conf 
+          dest: '{{ stage_dir }}/httpd-confs/httpd-vhosts-prod-fastapi.conf'
+        when: REDIRECT_HTTP | bool
 
       - name: install ssl configs from templates directory
         template:

--- a/provision/templates/httpd-vhosts-prod-fastapi-redirect.conf
+++ b/provision/templates/httpd-vhosts-prod-fastapi-redirect.conf
@@ -1,0 +1,7 @@
+<VirtualHost *:80>
+    ServerAdmin admin@localhost
+    ServerName {{ fastapi_host }}
+    ServerAlias {{ fastapi_host_alias }}
+
+    Redirect / https://{{ redirect_to }}/
+</VirtualHost>

--- a/provision/vars.yaml
+++ b/provision/vars.yaml
@@ -8,3 +8,6 @@ solr_url: http://golr-aux.geneontology.io/solr/
 sparql_url: http://rdf.geneontology.org/sparql
 fastapi_host: REPLACE_ME
 fastapi_host_alias: '{{ fastapi_host }}'
+
+REDIRECT_HTTP: 0
+redirect_to: REPLACE_ME


### PR DESCRIPTION
Added option to enable redirect from http to https.

see production/config-stack.yaml.sample
To enable set:

REDIRECT_HTTP: 1
redirect_to: FQDN