### PR TITLE
now allowing a dns record to be created by the go-deploy tool

### DIFF
--- a/provision/aws/main.tf
+++ b/provision/aws/main.tf
@@ -37,11 +37,26 @@ variable "ami" {
   default = "ami-019eb5c97ad39d701"
 }
 
+// optional will be created if value is not an menty string
+variable "dns_record_name" {
+  type = string
+  description = "type A DNS record wich will be mapped to public ip"
+  default = ""
+}
+
+variable "dns_zone_id" {
+  type = string
+  description = "zone id for dns record."
+  default = ""
+}
+
 module "base" {
-  source = "git::https://github.com/geneontology/devops-aws-go-instance.git?ref=V2.1"
+  source = "git::https://github.com/geneontology/devops-aws-go-instance.git?ref=V3.0"
   instance_type = var.instance_type
   ami = var.ami
   use_elastic_ip = var.use_elastic_ip 
+  dns_record_name = var.dns_record_name
+  dns_zone_id = var.dns_zone_id
   public_key_path = var.public_key_path
   tags = var.tags
   open_ports = var.open_ports

--- a/provision/production/PRODUCTION_PROVISION_README.md
+++ b/provision/production/PRODUCTION_PROVISION_README.md
@@ -11,7 +11,7 @@ This guide describes the deployment of the `go-fastapi` stack to AWS using Terra
 - Terraform: v1.1.4
 - Ansible: 2.10.7
 - aws cli
-- go-deploy: `poetry install go-deploy==0.4.1` # requires python >=3.8
+- go-deploy: `poetry install go-deploy==0.4.2` # requires python >=3.8
 
 #### configuration files:
 
@@ -32,7 +32,8 @@ This guide describes the deployment of the `go-fastapi` stack to AWS using Terra
 
 #### DNS: 
 
-DNS record is used for `go-fastapi`. Once the instance has been provisioned, you would need to point this record to the elastic IP of the VM. For testing purposes, you can use: `aes-test-go-fastapi.geneontology.org`
+DNS record is used for `go-fastapi` and the go-deploy tool allows for creating a DNS record of type A that would be populated by the public ip address of the aws instance. If
+you don't use this option, you would need to point this record to the elastic IP of the VM. For testing purposes, you can use: `aes-test-go-fastapi.geneontology.org`
 
 **NOTE**: if using cloudflare, you would need to point the cloudflare dns record to the elastic IP.
 
@@ -110,8 +111,13 @@ go-deploy --workspace REPLACE_ME_WITH_TERRAFORM_BACKEND --working-directory aws 
 7. deploy if all looks good.
 ```bash
 go-deploy --workspace REPLACE_ME_WITH_TERRAFORM_BACKEND --working-directory aws -verbose --conf config-instance.yaml
+# display the terraform state. The aws resources that were created.
+go-deploy --workspace REPLACE_ME_WITH_TERRAFORM_BACKEND --working-directory aws -verbose -show
+# display the public ip address of the aws instance
+go-deploy --workspace REPLACE_ME_WITH_TERRAFORM_BACKEND --working-directory aws -verbose -output
 ```
 
+Useful Details for troubleshooting:
 This will produce an IP address in the resulting inventory.json file.
 The previous command creates a terraform tfvars. These variables override the variables in `aws/main.tf`
 
@@ -205,6 +211,13 @@ docker inspect --format "{{json .State.Health }}" go-fastapi
 ### Destroy Instance and Delete Workspace:
 
 ```bash
+# Destroy Using Tool.
+# Make sure you point to the correct workspace before destroying the stack by using the -show command or the -output command
+go-deploy --workspace REPLACE_ME_WITH_TERRAFORM_BACKEND --working-directory aws -verbose -destroy
+```
+
+```bash
+# Destroy Manually
 # Make sure you point to the correct workspace before destroying the stack.
 
 terraform -chdir=aws workspace list
@@ -223,14 +236,14 @@ terraform -chdir=aws workspace delete <NAME_OF_WORKSPACE_THAT_IS_NOT_DEFAULT>  #
 1. start the docker container `go-dev` in interactive mode.
 
 ```bash
-docker run --rm --name go-dev -it geneontology/go-devops-base:tools-jammy-0.4.1  /bin/bash
+docker run --rm --name go-dev -it geneontology/go-devops-base:tools-jammy-0.4.2  /bin/bash
 ```
 
 In the command above we used the `--rm` option which means the container will be deleted when you exit.
 If that is not the intent and you want to delete it later at your own convenience. Use the following `docker run` command.
 
 ```bash
-docker run --name go-dev -it geneontology/go-devops-base:tools-jammy-0.4.1  /bin/bash
+docker run --name go-dev -it geneontology/go-devops-base:tools-jammy-0.4.2  /bin/bash
 ```
 
 2. To exit or stop the container:

--- a/provision/production/config-instance.yaml.sample
+++ b/provision/production/config-instance.yaml.sample
@@ -7,6 +7,12 @@ instance:
        Name: REPLACE_ME  # This will be the tag used in AWS 
     instance_type: t2.large
     use_elastic_ip: True 
+
+    # Set the fqdn if you want the record to be created  and make sure you have the right zone id. (See AWS console)
+    # The created record will be of type A and will be populated with the public ip address of the aws instance
+    dns_record_name: ""  
+    dns_zone_id: ""
+
     disk_size: 200
     open_ports:
        - 80

--- a/provision/production/config-stack.yaml.sample
+++ b/provision/production/config-stack.yaml.sample
@@ -20,11 +20,10 @@ stack:
       QS_ClientEventBlockCountSeconds: 100
       QS_ClientEventBlockExcludeIP: "9.9.9.9"
 
-      fastapi_host: REPLACE_ME # aes-test-go-fastapi
+      fastapi_host: REPLACE_ME # USE FQDN aes-test-go-fastapi.geneontology.org
       fastapi_tag: 0.2.0
 
       REDIRECT_HTTP: 1
-      redirect_to: REPLACE_ME # aes-test-go-fastapi.geneontology.org
 
       USE_CLOUDFLARE: 0  # Enable if planning to use behind proxy
    scripts: [ "stage.yaml", "start_services.yaml" ]

--- a/provision/vars.yaml
+++ b/provision/vars.yaml
@@ -8,7 +8,8 @@ solr_url: http://golr-aux.geneontology.io/solr/
 sparql_url: http://rdf.geneontology.org/sparql
 fastapi_host: REPLACE_ME
 fastapi_host_alias: '{{ fastapi_host }}'
+
 REDIRECT_HTTP: 0
-redirect_to: REPLACE_ME
+redirect_to: '{{ fastapi_host }}'
 
 USE_CLOUDFLARE: 0


### PR DESCRIPTION
- The go-deploy version is now 0.4.2. Please upgrade using `pip install --upgrade go-deploy` or
- Or use the latest devops docker image geneontology/go-devops-base:tools-jammy-0.4.2
- The version of the devops-aws-go-instance is now V3.0. See aws/main.tf. This version allows for creating a dns record that gets populated automatically with the public ip address of the instance by specifying `dns_record_name` and `dns_zone_id` in the instance yaml config file. See production/config-instance.yaml.sample
- It is recommended to use FQDNs for `fastapi_host` and `fastapi_host_alias`
- The redirect_to is no longer needed in the stack config yaml file if the `fastapi_host` is configured as an FQDN.