### PR TITLE
Gocam model integration

### DIFF
--- a/app/routers/models.py
+++ b/app/routers/models.py
@@ -2,10 +2,12 @@
 
 import logging
 from http.client import HTTPException
-from typing import List
 from pprint import pprint
+from typing import List
+
 import requests
 from fastapi import APIRouter, Path, Query
+from gocam.translation.minerva_wrapper import MinervaWrapper
 from oaklib.implementations.sparql.sparql_implementation import SparqlImplementation
 from oaklib.resource import OntologyResource
 
@@ -13,17 +15,19 @@ from app.exceptions.global_exceptions import DataNotFoundException, InvalidIdent
 from app.utils import ontology_utils
 from app.utils.settings import get_sparql_endpoint, get_user_agent
 from app.utils.sparql_utils import transform_array
-from gocam.datamodel.gocam import Model
-from gocam.translation.minerva_wrapper import MinervaWrapper
 
 USER_AGENT = get_user_agent()
 SPARQL_ENDPOINT = get_sparql_endpoint()
 router = APIRouter()
 
 logger = logging.getLogger()
-@router.get("/api/gocam-model/{id}",
-            tags=["models"],
-            description="Returns model details in gocam-py format based on a GO-CAM model ID.")
+
+
+@router.get(
+    "/api/gocam-model/{id}",
+    tags=["models"],
+    description="Returns model details in gocam-py format based on a GO-CAM model ID.",
+)
 async def get_gocam_model_by_id_in_gocam_py_format(
     id: str = Path(
         ...,
@@ -37,7 +41,6 @@ async def get_gocam_model_by_id_in_gocam_py_format(
     :param id: A GO-CAM identifier (e.g. 581e072c00000820, 581e072c00000295, 5900dc7400000968)
     :return: model details in gocam-py format based on a GO-CAM model ID.
     """
-
     mw = MinervaWrapper()
     stripped_ids = []
     if id.startswith("gomodel:"):
@@ -59,7 +62,7 @@ async def get_gocam_model_by_id_in_gocam_py_format(
             pprint(gocam_reposnse)
             return gocam_reposnse.model_dump()
         except Exception as e:
-            raise HTTPException(status_code=500, detail=f"Unexpected error: {e}")
+            raise HTTPException(status_code=500, detail=f"Unexpected error: {e}") from e
 
 
 @router.get("/api/models/go", tags=["models"], description="Returns go term details based on a GO-CAM model ID.")
@@ -355,7 +358,7 @@ async def get_pmid_by_model_id(
 
 @router.get(
     "/api/go-cam/{id}", tags=["models"], description="Returns model details based on a GO-CAM model ID in JSON format."
-)
+)  # note: this is the endpoint that is currently used by gocam-py to for use in CTX export.
 async def get_model_details_by_model_id_json(
     id: str = Path(
         ...,

--- a/app/utils/sparql_utils.py
+++ b/app/utils/sparql_utils.py
@@ -1,10 +1,19 @@
 """Utils for SPARQL queries."""
 
-from fastapi.responses import ORJSONResponse
 from typing import Any
 
+from fastapi.responses import ORJSONResponse
+
+
 def create_response(data: Any):
+    """
+    Create a response with the given data.
+
+    :param data:
+    :return:
+    """
     return ORJSONResponse(content=data.dict())
+
 
 SEPARATOR = "|"  # separator for splitting values
 

--- a/app/utils/sparql_utils.py
+++ b/app/utils/sparql_utils.py
@@ -1,5 +1,11 @@
 """Utils for SPARQL queries."""
 
+from fastapi.responses import ORJSONResponse
+from typing import Any
+
+def create_response(data: Any):
+    return ORJSONResponse(content=data.dict())
+
 SEPARATOR = "|"  # separator for splitting values
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1058,6 +1058,26 @@ paramiko = ">=2.11.0"
 pyyaml = ">=6.0"
 
 [[package]]
+name = "gocam"
+version = "0.2.0"
+description = "GO CAM Data Model (Python)"
+optional = false
+python-versions = "<4.0,>=3.9"
+files = [
+    {file = "gocam-0.2.0-py3-none-any.whl", hash = "sha256:8d7e1ab8d9738a7aaf98936bb02be14af7f616aa6d1c7d0962cff3ff23aa2567"},
+    {file = "gocam-0.2.0.tar.gz", hash = "sha256:111400e2d456b92b6c8b0dc6659a0098c7c0e4e3b9ed3939ec4198bb71473543"},
+]
+
+[package.dependencies]
+click = ">=8,<9"
+linkml-runtime = ">=1.1.24,<2.0.0"
+ndex2 = ">=3.9.0,<4.0.0"
+prefixmaps = ">=0.2.5,<0.3.0"
+pydantic = ">=2,<3"
+pyyaml = ">=6,<7"
+requests = ">=2,<3"
+
+[[package]]
 name = "graphviz"
 version = "0.20.1"
 description = "Simple Python interface for Graphviz"
@@ -4731,4 +4751,4 @@ docs = []
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10.1"
-content-hash = "8d735ddb93eee233c8804c96352332e7c2ef8aa179a262ff726340a198f005fb"
+content-hash = "b3a521fa31789a40aefc15f9a85f155311fa8e63d6fb9bc36640dc4260ea3b20"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ go-deploy = ">=0.4.1"
 biothings-client = "^0.3.0"
 email-validator = "^2.0.0.post2"
 bmt = "^1.1.2"
+gocam = "^0.2.0"
 
 [tool.poetry.dev-dependencies]
 pytest = ">=7.4.0"

--- a/tests/unit/test_models_endpoints.py
+++ b/tests/unit/test_models_endpoints.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 from requests import HTTPError
 
 from app.main import app
+from tests.integration.step_defs.bioentity_function_steps import response_code
 
 logging.basicConfig(filename="combined_access_error.log", level=logging.INFO, format="%(asctime)s - %(message)s")
 logger = logging.getLogger()
@@ -151,6 +152,16 @@ class TestApp(unittest.TestCase):
             self.assertGreater(len(response.json().get("individuals")), 0)
             self.assertGreater(len(response.json().get("facts")), 0)
 
+    def test_get_model_details_by_model_id_json_gocam_py(self):
+        """
+        Test the endpoint to retrieve model details by model ID in JSON format from the S3 bucket, check for success.
+
+        :return: None
+        """
+        for id in go_cam_ids:
+            response = test_client.get(f"/api/gocam-model/{id}")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.json().get("id"), "gomodel:" + id.replace("gomodel:", ""))
 
     def test_get_model_details_by_model_id_not_found_json(self):
         """


### PR DESCRIPTION
- use gocam-py LinkML model to return models in that format instead of minerva JSON. 
- for now, this PR creates a new endpoint, instead of refactoring an old endpoint as we're not sure of the usage of all these different, redundant models endpoints. 
- we also need a PR when this goes live in production, to change the API call in gocam-py to point to this new endpoint as a pass-through, instead of converting in both places. 

