### PR TITLE
force tox to use poetry environment

### DIFF
--- a/.github/workflows/pr-test-qc.yaml
+++ b/.github/workflows/pr-test-qc.yaml
@@ -33,4 +33,4 @@ jobs:
         run: poetry run tox -e lint
 
       - name: Test with pytest and generate coverage file
-        run: poetry run tox -e py
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,13 @@ integration-tests:
 	poetry run pytest tests/integration/step_defs/*.py
 
 lint:
-	poetry run tox -e flake8
 	poetry run tox -e lint-fix
 
 spell:
 	poetry run tox -e codespell
+
+spell-fix:
+	poetry run tox -e codespell-write
 
 unit-tests:
 	poetry run pytest -v tests/unit/*.py

--- a/app/exceptions/global_exceptions.py
+++ b/app/exceptions/global_exceptions.py
@@ -4,6 +4,7 @@ from fastapi import HTTPException
 
 
 class DataNotFoundException(HTTPException):
+
     """
     Exception for when data is not found.
 
@@ -25,6 +26,7 @@ class DataNotFoundException(HTTPException):
 
 
 class InvalidIdentifier(HTTPException):
+
     """
     Exception for when data is not found.
 

--- a/app/middleware/logging_middleware.py
+++ b/app/middleware/logging_middleware.py
@@ -13,6 +13,7 @@ logger.setLevel(logging.INFO)
 
 
 class LoggingMiddleware(BaseHTTPMiddleware):
+
     """Middleware to log requests."""
 
     async def dispatch(self, request: Request, call_next):

--- a/app/routers/bioentity.py
+++ b/app/routers/bioentity.py
@@ -32,6 +32,7 @@ logger = logging.getLogger()
 
 
 class RelationshipType(str, Enum):
+
     """
     Enumeration for Gene Ontology relationship types used for filtering associations.
 

--- a/app/routers/ontology.py
+++ b/app/routers/ontology.py
@@ -26,6 +26,7 @@ router = APIRouter()
 
 
 class GraphType(str, Enum):
+
     """Enum for the different types of graphs that can be returned."""
 
     topology_graph = "topology_graph"
@@ -327,6 +328,7 @@ async def get_go_term_detail_by_go_id(
 
 
 class GOHierarchyItem(BaseModel):
+
     """
     A GO Hierarchy return model.
 

--- a/app/routers/search.py
+++ b/app/routers/search.py
@@ -16,6 +16,7 @@ router = APIRouter()
 
 
 class AutocompleteCategory(str, Enum):
+
     """The category of items to retrieve, can be 'gene' or 'term'."""
 
     gene = "gene"

--- a/app/routers/slimmer.py
+++ b/app/routers/slimmer.py
@@ -22,6 +22,7 @@ logger = logging.getLogger()
 
 
 class RelationshipType(str, Enum):
+
     """Relationship type for slimmer."""
 
     acts_upstream_of_or_within = ACTS_UPSTREAM_OF_OR_WITHIN

--- a/app/utils/settings.py
+++ b/app/utils/settings.py
@@ -42,18 +42,21 @@ def get_golr_config():
 
 
 class ESOLR(Enum):
+
     """Enum for the GOLR URL."""
 
     GOLR = get_golr_config()["solr_url"]["url"]
 
 
 class ESPARQL(Enum):
+
     """Enum for the SPARQL endpoint URL."""
 
     SPARQL = get_sparql_endpoint()
 
 
 class ESOLRDoc(Enum):
+
     """Enum for the GOLR document type."""
 
     ONTOLOGY = "ontology_class"

--- a/poetry.lock
+++ b/poetry.lock
@@ -250,6 +250,52 @@ dataframe = ["pandas (>=0.18.0)"]
 jsonld = ["PyLD (>=0.7.2)"]
 
 [[package]]
+name = "black"
+version = "23.12.1"
+description = "The uncompromising code formatter."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "black-23.12.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e0aaf6041986767a5e0ce663c7a2f0e9eaf21e6ff87a5f95cbf3675bfd4c41d2"},
+    {file = "black-23.12.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c88b3711d12905b74206227109272673edce0cb29f27e1385f33b0163c414bba"},
+    {file = "black-23.12.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a920b569dc6b3472513ba6ddea21f440d4b4c699494d2e972a1753cdc25df7b0"},
+    {file = "black-23.12.1-cp310-cp310-win_amd64.whl", hash = "sha256:3fa4be75ef2a6b96ea8d92b1587dd8cb3a35c7e3d51f0738ced0781c3aa3a5a3"},
+    {file = "black-23.12.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8d4df77958a622f9b5a4c96edb4b8c0034f8434032ab11077ec6c56ae9f384ba"},
+    {file = "black-23.12.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:602cfb1196dc692424c70b6507593a2b29aac0547c1be9a1d1365f0d964c353b"},
+    {file = "black-23.12.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c4352800f14be5b4864016882cdba10755bd50805c95f728011bcb47a4afd59"},
+    {file = "black-23.12.1-cp311-cp311-win_amd64.whl", hash = "sha256:0808494f2b2df923ffc5723ed3c7b096bd76341f6213989759287611e9837d50"},
+    {file = "black-23.12.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:25e57fd232a6d6ff3f4478a6fd0580838e47c93c83eaf1ccc92d4faf27112c4e"},
+    {file = "black-23.12.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2d9e13db441c509a3763a7a3d9a49ccc1b4e974a47be4e08ade2a228876500ec"},
+    {file = "black-23.12.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d1bd9c210f8b109b1762ec9fd36592fdd528485aadb3f5849b2740ef17e674e"},
+    {file = "black-23.12.1-cp312-cp312-win_amd64.whl", hash = "sha256:ae76c22bde5cbb6bfd211ec343ded2163bba7883c7bc77f6b756a1049436fbb9"},
+    {file = "black-23.12.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1fa88a0f74e50e4487477bc0bb900c6781dbddfdfa32691e780bf854c3b4a47f"},
+    {file = "black-23.12.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:a4d6a9668e45ad99d2f8ec70d5c8c04ef4f32f648ef39048d010b0689832ec6d"},
+    {file = "black-23.12.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b18fb2ae6c4bb63eebe5be6bd869ba2f14fd0259bda7d18a46b764d8fb86298a"},
+    {file = "black-23.12.1-cp38-cp38-win_amd64.whl", hash = "sha256:c04b6d9d20e9c13f43eee8ea87d44156b8505ca8a3c878773f68b4e4812a421e"},
+    {file = "black-23.12.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3e1b38b3135fd4c025c28c55ddfc236b05af657828a8a6abe5deec419a0b7055"},
+    {file = "black-23.12.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4f0031eaa7b921db76decd73636ef3a12c942ed367d8c3841a0739412b260a54"},
+    {file = "black-23.12.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:97e56155c6b737854e60a9ab1c598ff2533d57e7506d97af5481141671abf3ea"},
+    {file = "black-23.12.1-cp39-cp39-win_amd64.whl", hash = "sha256:dd15245c8b68fe2b6bd0f32c1556509d11bb33aec9b5d0866dd8e2ed3dba09c2"},
+    {file = "black-23.12.1-py3-none-any.whl", hash = "sha256:78baad24af0f033958cad29731e27363183e140962595def56423e626f4bee3e"},
+    {file = "black-23.12.1.tar.gz", hash = "sha256:4ce3ef14ebe8d9509188014d96af1c456a910d5b5cbf434a09fef7e024b3d0d5"},
+]
+
+[package.dependencies]
+click = ">=8.0.0"
+mypy-extensions = ">=0.4.3"
+packaging = ">=22.0"
+pathspec = ">=0.9.0"
+platformdirs = ">=2"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+typing-extensions = {version = ">=4.0.1", markers = "python_version < \"3.11\""}
+
+[package.extras]
+colorama = ["colorama (>=0.4.3)"]
+d = ["aiohttp (>=3.7.4)", "aiohttp (>=3.7.4,!=3.9.0)"]
+jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
+uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
 name = "bleach"
 version = "6.0.0"
 description = "An easy safelist-based HTML-sanitizing tool."
@@ -550,6 +596,23 @@ files = [
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[[package]]
+name = "codespell"
+version = "2.4.1"
+description = "Fix common misspellings in text files"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "codespell-2.4.1-py3-none-any.whl", hash = "sha256:3dadafa67df7e4a3dbf51e0d7315061b80d265f9552ebd699b3dd6834b47e425"},
+    {file = "codespell-2.4.1.tar.gz", hash = "sha256:299fcdcb09d23e81e35a671bbe746d5ad7e8385972e65dbb833a2eaac33c01e5"},
+]
+
+[package.extras]
+dev = ["Pygments", "build", "chardet", "pre-commit", "pytest", "pytest-cov", "pytest-dependency", "ruff", "tomli", "twine"]
+hard-encoding-detection = ["chardet"]
+toml = ["tomli"]
+types = ["chardet (>=5.1.0)", "mypy", "pytest", "pytest-cov", "pytest-dependency"]
 
 [[package]]
 name = "colorama"
@@ -2318,6 +2381,17 @@ files = [
 ]
 
 [[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+description = "Type system extensions for programs checked with the mypy type checker."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505"},
+    {file = "mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558"},
+]
+
+[[package]]
 name = "ndex2"
 version = "3.9.0"
 description = "Nice CX Python includes a client and a data model."
@@ -2664,6 +2738,17 @@ six = ">=1.11"
 [package.extras]
 develop = ["coverage (>=4.4)", "pytest (<5.0)", "pytest (>=5.0)", "pytest-cov", "pytest-html (>=1.19.0)", "tox (>=2.8)"]
 docs = ["sphinx (>=1.2)"]
+
+[[package]]
+name = "pathspec"
+version = "0.12.1"
+description = "Utility library for gitignore style pattern matching of file paths."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
+    {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
+]
 
 [[package]]
 name = "pillow"
@@ -3771,6 +3856,33 @@ files = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.6.9"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.6.9-py3-none-linux_armv6l.whl", hash = "sha256:064df58d84ccc0ac0fcd63bc3090b251d90e2a372558c0f057c3f75ed73e1ccd"},
+    {file = "ruff-0.6.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:140d4b5c9f5fc7a7b074908a78ab8d384dd7f6510402267bc76c37195c02a7ec"},
+    {file = "ruff-0.6.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:53fd8ca5e82bdee8da7f506d7b03a261f24cd43d090ea9db9a1dc59d9313914c"},
+    {file = "ruff-0.6.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:645d7d8761f915e48a00d4ecc3686969761df69fb561dd914a773c1a8266e14e"},
+    {file = "ruff-0.6.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eae02b700763e3847595b9d2891488989cac00214da7f845f4bcf2989007d577"},
+    {file = "ruff-0.6.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7d5ccc9e58112441de8ad4b29dcb7a86dc25c5f770e3c06a9d57e0e5eba48829"},
+    {file = "ruff-0.6.9-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:417b81aa1c9b60b2f8edc463c58363075412866ae4e2b9ab0f690dc1e87ac1b5"},
+    {file = "ruff-0.6.9-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3c866b631f5fbce896a74a6e4383407ba7507b815ccc52bcedabb6810fdb3ef7"},
+    {file = "ruff-0.6.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7b118afbb3202f5911486ad52da86d1d52305b59e7ef2031cea3425142b97d6f"},
+    {file = "ruff-0.6.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a67267654edc23c97335586774790cde402fb6bbdb3c2314f1fc087dee320bfa"},
+    {file = "ruff-0.6.9-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:3ef0cc774b00fec123f635ce5c547dac263f6ee9fb9cc83437c5904183b55ceb"},
+    {file = "ruff-0.6.9-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:12edd2af0c60fa61ff31cefb90aef4288ac4d372b4962c2864aeea3a1a2460c0"},
+    {file = "ruff-0.6.9-py3-none-musllinux_1_2_i686.whl", hash = "sha256:55bb01caeaf3a60b2b2bba07308a02fca6ab56233302406ed5245180a05c5625"},
+    {file = "ruff-0.6.9-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:925d26471fa24b0ce5a6cdfab1bb526fb4159952385f386bdcc643813d472039"},
+    {file = "ruff-0.6.9-py3-none-win32.whl", hash = "sha256:eb61ec9bdb2506cffd492e05ac40e5bc6284873aceb605503d8494180d6fc84d"},
+    {file = "ruff-0.6.9-py3-none-win_amd64.whl", hash = "sha256:785d31851c1ae91f45b3d8fe23b8ae4b5170089021fbb42402d811135f0b7117"},
+    {file = "ruff-0.6.9-py3-none-win_arm64.whl", hash = "sha256:a9641e31476d601f83cd602608739a0840e348bda93fec9f1ee816f8b6798b93"},
+    {file = "ruff-0.6.9.tar.gz", hash = "sha256:b076ef717a8e5bc819514ee1d602bbdca5b4420ae13a9cf61a0c0a4f53a2baa2"},
+]
+
+[[package]]
 name = "scipy"
 version = "1.9.3"
 description = "Fundamental algorithms for scientific computing in Python"
@@ -4753,4 +4865,4 @@ docs = []
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10.1"
-content-hash = "ebd8ef28ff70fbb643a4535e99d496ed8bd14f5b10a34cb3ff49d8a34f85fa49"
+content-hash = "9c832ae0ccb5f29583f38545e0f22b6fa71c07e2b306c5dfa7ef4726ded97f4b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ docs = ["Sphinx", "sphinx-rtd-theme", "sphinxcontrib-mermaid"]
 
 [tool.black]
 line-length = 120
-target-version = ["py39", "py310"]
+target-version = ["py311", "py312"]
 
 [tool.ruff]
 extend-ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ bmt = "^1.1.2"
 gocam = "^0.4.0"
 
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = ">=7.4.0"
 pytest-bdd = "^6.1.1"
 Sphinx = "^5.0.2"
@@ -40,6 +40,10 @@ sphinx-rtd-theme = ">=1.2.2"
 sphinxcontrib-napoleon = "^0.7"
 tox = ">=4.6.4"
 httpx = ">=0.18.2"
+ruff = "^0.6.9"
+black = "^23.1.0"
+codespell = "^2.2.0"
+tomli = "^2.0.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,6 @@ commands = coverage erase
 skip_install = true
 commands =
     poetry run ruff check --fix app/
-    poetry run black app/
 description = Auto-fix with Ruff and Black.
 
 # This is used for QC checks.
@@ -43,7 +42,6 @@ description = Auto-fix with Ruff and Black.
 skip_install = true
 commands =
     poetry run ruff check app/
-    poetry run black --check app/
 description = Lint with Ruff and Black.
 
 [testenv:doclint]

--- a/tox.ini
+++ b/tox.ini
@@ -31,25 +31,20 @@ deps = coverage
 skip_install = true
 commands = coverage erase
 
-# This is used during development
 [testenv:lint-fix]
-deps =
-    black
-    ruff
 skip_install = true
 commands =
-    ruff --fix app/
-    black app/
-description = Run linters.
+    poetry run ruff check --fix app/
+    poetry run black app/
+description = Auto-fix with Ruff and Black.
 
 # This is used for QC checks.
 [testenv:lint]
-deps =
-    black
 skip_install = true
 commands =
-    black --check --diff app/
-description = Run linters.
+    poetry run ruff check app/
+    poetry run black --check app/
+description = Lint with Ruff and Black.
 
 [testenv:doclint]
 deps =
@@ -62,18 +57,12 @@ description = Run documentation linters.
 [testenv:codespell]
 description = Run spell checker.
 skip_install = true
-deps =
-    codespell
-    tomli  # required for getting config from pyproject.toml
-commands = codespell app/
+commands = poetry run codespell app/
 
 [testenv:codespell-write]
 description = Run spell checker and write corrections.
 skip_install = true
-deps =
-    codespell
-    tomli
-commands = codespell app/ --write-changes
+commands = poetry run codespell app/ --write-changes
 
 [testenv:docstr-coverage]
 skip_install = true


### PR DESCRIPTION
- force tox to use poetry env as defined in pyproject.toml and poetry.lock (added black, ruff, codespell to dev dependency block and updated style of dev dependencies in line with poetry suggestions)
- refactor slightly the make targets for fixing linting errors so that they do as much as possible themselves.
- make CI/CD environment match local environment so codespell, ruff don't complain on CI but pass locally.
