### PR TITLE
Update causal GO-CAM SPARQL to also detect metabolic models 

### DIFF
--- a/app/routers/pathway_widget.py
+++ b/app/routers/pathway_widget.py
@@ -85,90 +85,118 @@ async def get_gocams_by_geneproduct_id(
     if causalmf == 2:
         query = (
             """
-      PREFIX pr: <http://purl.org/ontology/prv/core#>
-      PREFIX metago: <http://model.geneontology.org/>
-      PREFIX dc: <http://purl.org/dc/elements/1.1/>
-      PREFIX providedBy: <http://purl.org/pav/providedBy>
-      PREFIX MF: <http://purl.obolibrary.org/obo/GO_0003674>
-      PREFIX causally_upstream_of_or_within: <http://purl.obolibrary.org/obo/RO_0002418>
-      PREFIX causally_upstream_of_or_within_negative_effect: <http://purl.obolibrary.org/obo/RO_0004046>
-      PREFIX causally_upstream_of_or_within_positive_effect: <http://purl.obolibrary.org/obo/RO_0004047>
-      PREFIX causally_upstream_of: <http://purl.obolibrary.org/obo/RO_0002411>
-      PREFIX causally_upstream_of_negative_effect: <http://purl.obolibrary.org/obo/RO_0002305>
-      PREFIX causally_upstream_of_positive_effect: <http://purl.obolibrary.org/obo/RO_0002304>
-      PREFIX regulates: <http://purl.obolibrary.org/obo/RO_0002211>
-      PREFIX negatively_regulates: <http://purl.obolibrary.org/obo/RO_0002212>
-      PREFIX positively_regulates: <http://purl.obolibrary.org/obo/RO_0002213>
-      PREFIX directly_regulates: <http://purl.obolibrary.org/obo/RO_0002578>
-      PREFIX directly_positively_regulates: <http://purl.obolibrary.org/obo/RO_0002629>
-      PREFIX directly_negatively_regulates: <http://purl.obolibrary.org/obo/RO_0002630>
-      PREFIX directly_activates: <http://purl.obolibrary.org/obo/RO_0002406>
-      PREFIX indirectly_activates: <http://purl.obolibrary.org/obo/RO_0002407>
-      PREFIX directly_inhibits: <http://purl.obolibrary.org/obo/RO_0002408>
-      PREFIX indirectly_inhibits: <http://purl.obolibrary.org/obo/RO_0002409>
-      PREFIX transitively_provides_input_for: <http://purl.obolibrary.org/obo/RO_0002414>
-      PREFIX immediately_causally_upstream_of: <http://purl.obolibrary.org/obo/RO_0002412>
-      PREFIX directly_provides_input_for: <http://purl.obolibrary.org/obo/RO_0002413>
-      PREFIX enabled_by: <http://purl.obolibrary.org/obo/RO_0002333>
-      PREFIX hint: <http://www.bigdata.com/queryHints#>
-      SELECT DISTINCT ?gocam ?title
-      WHERE {
-        GRAPH ?gocam  {
-          # Inject gene product ID here
-          ?gene rdf:type <%s> .
-        }
-        FILTER EXISTS {
-          ?gocam metago:graphType metago:noctuaCam .
-        }
-        ?gocam dc:title ?title .
-        FILTER (
-          EXISTS {
-            GRAPH ?gocam  {      ?ind1 enabled_by: ?gene . }
-            GRAPH ?gocam { ?ind1 ?causal1 ?ind2 }
-            ?causal1 rdfs:subPropertyOf* causally_upstream_of_or_within: .
-            ?ind1 causally_upstream_of_or_within: ?ind2 .
-            GRAPH ?gocam  {       ?ind2 enabled_by: ?gpnode2 . }
-            GRAPH ?gocam { ?ind2 ?causal2 ?ind3 }
-            ?causal2 rdfs:subPropertyOf* causally_upstream_of_or_within: .
-            ?ind2 causally_upstream_of_or_within: ?ind3 .
-            GRAPH ?gocam  {       ?ind3 enabled_by: ?gpnode3 . }
-            FILTER(?gene != ?gpnode2)
-            FILTER(?gene != ?gpnode3)
-            FILTER(?gpnode2 != ?gpnode3)
-          } ||
-          EXISTS {
-            GRAPH ?gocam  {       ?ind1 enabled_by: ?gpnode1 . }
-            GRAPH ?gocam { ?ind1 ?causal1 ?ind2 }
-            ?causal1 rdfs:subPropertyOf* causally_upstream_of_or_within: .
-            ?ind1 causally_upstream_of_or_within: ?ind2 .
-            GRAPH ?gocam  {          ?ind2 enabled_by: ?gene . }
-            GRAPH ?gocam { ?ind2 ?causal2 ?ind3 }
-            ?causal2 rdfs:subPropertyOf* causally_upstream_of_or_within: .
-            ?ind2 causally_upstream_of_or_within: ?ind3 .
-            GRAPH ?gocam  {           ?ind3 enabled_by: ?gpnode3 . }
-            FILTER(?gpnode1 != ?gene)
-            FILTER(?gpnode1 != ?gpnode3)
-            FILTER(?gene != ?gpnode3)
-          } ||
-          EXISTS {
-            GRAPH ?gocam  {       ?ind1 enabled_by: ?gpnode1 . }
-            GRAPH ?gocam { ?ind1 ?causal1 ?ind2 }
-            ?causal1 rdfs:subPropertyOf* causally_upstream_of_or_within: .
-            ?ind1 causally_upstream_of_or_within: ?ind2 .
-            GRAPH ?gocam  {           ?ind2 enabled_by: ?gpnode2 . }
-            GRAPH ?gocam { ?ind2 ?causal2 ?ind3 }
-            ?causal2 rdfs:subPropertyOf* causally_upstream_of_or_within: .
-            ?ind2 causally_upstream_of_or_within: ?ind3 .
-            GRAPH ?gocam  {         ?ind3 enabled_by: ?gene . }
-            FILTER(?gpnode1 != ?gpnode2)
-            FILTER(?gpnode1 != ?gene)
-            FILTER(?gpnode2 != ?gene)
+        PREFIX pr: <http://purl.org/ontology/prv/core#>
+        PREFIX metago: <http://model.geneontology.org/>
+        PREFIX dc: <http://purl.org/dc/elements/1.1/>
+        PREFIX providedBy: <http://purl.org/pav/providedBy>
+        PREFIX MF: <http://purl.obolibrary.org/obo/GO_0003674>
+        PREFIX causally_upstream_of_or_within: <http://purl.obolibrary.org/obo/RO_0002418>
+        PREFIX causally_upstream_of_or_within_negative_effect: <http://purl.obolibrary.org/obo/RO_0004046>
+        PREFIX causally_upstream_of_or_within_positive_effect: <http://purl.obolibrary.org/obo/RO_0004047>
+        PREFIX causally_upstream_of: <http://purl.obolibrary.org/obo/RO_0002411>
+        PREFIX causally_upstream_of_negative_effect: <http://purl.obolibrary.org/obo/RO_0002305>
+        PREFIX causally_upstream_of_positive_effect: <http://purl.obolibrary.org/obo/RO_0002304>
+        PREFIX regulates: <http://purl.obolibrary.org/obo/RO_0002211>
+        PREFIX negatively_regulates: <http://purl.obolibrary.org/obo/RO_0002212>
+        PREFIX positively_regulates: <http://purl.obolibrary.org/obo/RO_0002213>
+        PREFIX directly_regulates: <http://purl.obolibrary.org/obo/RO_0002578>
+        PREFIX directly_positively_regulates: <http://purl.obolibrary.org/obo/RO_0002629>
+        PREFIX directly_negatively_regulates: <http://purl.obolibrary.org/obo/RO_0002630>
+        PREFIX directly_activates: <http://purl.obolibrary.org/obo/RO_0002406>
+        PREFIX indirectly_activates: <http://purl.obolibrary.org/obo/RO_0002407>
+        PREFIX directly_inhibits: <http://purl.obolibrary.org/obo/RO_0002408>
+        PREFIX indirectly_inhibits: <http://purl.obolibrary.org/obo/RO_0002409>
+        PREFIX transitively_provides_input_for: <http://purl.obolibrary.org/obo/RO_0002414>
+        PREFIX immediately_causally_upstream_of: <http://purl.obolibrary.org/obo/RO_0002412>
+        PREFIX directly_provides_input_for: <http://purl.obolibrary.org/obo/RO_0002413>
+        PREFIX enabled_by: <http://purl.obolibrary.org/obo/RO_0002333>
+        PREFIX has_input: <http://purl.obolibrary.org/obo/RO_0002233>
+        PREFIX has_output: <http://purl.obolibrary.org/obo/RO_0002234>
+        PREFIX REACTO: <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#>
+        PREFIX hint: <http://www.bigdata.com/queryHints#>
+        SELECT DISTINCT ?gocam ?title
+        WHERE {
+          {
+            GRAPH ?gocam  {
+              # Inject gene product ID here
+              ?gene rdf:type <%s> .
+            }
+            FILTER EXISTS {
+              ?gocam metago:graphType metago:noctuaCam .
+            }
+            ?gocam dc:title ?title .
+            FILTER (
+              EXISTS {
+                GRAPH ?gocam  {      ?ind1 enabled_by: ?gene . }
+                GRAPH ?gocam { ?ind1 ?causal1 ?ind2 }
+                ?causal1 rdfs:subPropertyOf* causally_upstream_of_or_within: .
+                ?ind1 causally_upstream_of_or_within: ?ind2 .
+                GRAPH ?gocam  {       ?ind2 enabled_by: ?gpnode2 . }
+                GRAPH ?gocam { ?ind2 ?causal2 ?ind3 }
+                ?causal2 rdfs:subPropertyOf* causally_upstream_of_or_within: .
+                ?ind2 causally_upstream_of_or_within: ?ind3 .
+                GRAPH ?gocam  {       ?ind3 enabled_by: ?gpnode3 . }
+                FILTER(?gene != ?gpnode2)
+                FILTER(?gene != ?gpnode3)
+                FILTER(?gpnode2 != ?gpnode3)
+              } ||
+              EXISTS {
+                GRAPH ?gocam  {       ?ind1 enabled_by: ?gpnode1 . }
+                GRAPH ?gocam { ?ind1 ?causal1 ?ind2 }
+                ?causal1 rdfs:subPropertyOf* causally_upstream_of_or_within: .
+                ?ind1 causally_upstream_of_or_within: ?ind2 .
+                GRAPH ?gocam  {          ?ind2 enabled_by: ?gene . }
+                GRAPH ?gocam { ?ind2 ?causal2 ?ind3 }
+                ?causal2 rdfs:subPropertyOf* causally_upstream_of_or_within: .
+                ?ind2 causally_upstream_of_or_within: ?ind3 .
+                GRAPH ?gocam  {           ?ind3 enabled_by: ?gpnode3 . }
+                FILTER(?gpnode1 != ?gene)
+                FILTER(?gpnode1 != ?gpnode3)
+                FILTER(?gene != ?gpnode3)
+              } ||
+              EXISTS {
+                GRAPH ?gocam  {       ?ind1 enabled_by: ?gpnode1 . }
+                GRAPH ?gocam { ?ind1 ?causal1 ?ind2 }
+                ?causal1 rdfs:subPropertyOf* causally_upstream_of_or_within: .
+                ?ind1 causally_upstream_of_or_within: ?ind2 .
+                GRAPH ?gocam  {           ?ind2 enabled_by: ?gpnode2 . }
+                GRAPH ?gocam { ?ind2 ?causal2 ?ind3 }
+                ?causal2 rdfs:subPropertyOf* causally_upstream_of_or_within: .
+                ?ind2 causally_upstream_of_or_within: ?ind3 .
+                GRAPH ?gocam  {         ?ind3 enabled_by: ?gene . }
+                FILTER(?gpnode1 != ?gpnode2)
+                FILTER(?gpnode1 != ?gene)
+                FILTER(?gpnode2 != ?gene)
+              }
+            )
           }
-        )
-      }
-      ORDER BY ?gocam
+          UNION
+          {
+            GRAPH ?gocam {
+               ?gene rdf:type <%s> .
+            }
+            FILTER EXISTS {
+              ?gocam metago:graphType metago:noctuaCam .
+            }
+            ?gocam dc:title ?title .
+            # Chemical intermediate connection
+            GRAPH ?gocam  {       ?ind1 enabled_by: ?gpnode1 . }
+            GRAPH ?gocam  {       ?ind2 enabled_by: ?gpnode2 . }
+            GRAPH ?gocam {
+              ?ind1 has_output: ?chem_ind1 .
+              ?ind2 has_input: ?chem_ind2 .
+              ?chem_ind1 a ?chem_type .
+              ?chem_ind2 a ?chem_type .
+              FILTER(?chem_type != owl:NamedIndividual) .
+            }
+            FILTER ( EXISTS { ?ind1 a MF: } || EXISTS { ?ind1 a REACTO:molecular_event } )
+            FILTER ( EXISTS { ?ind2 a MF: } || EXISTS { ?ind2 a REACTO:molecular_event } )
+            FILTER ( ?gpnode1 = ?gene || ?gpnode2 = ?gene )
+          }
+        }
+        ORDER BY ?gocam
     """
-            % id
+            %(id, id)
         )
     results = si._sparql_query(query)
     return transform_array(results)

--- a/tests/unit/test_pathway_widget_endpoints.py
+++ b/tests/unit/test_pathway_widget_endpoints.py
@@ -9,7 +9,7 @@ from app.main import app
 
 test_client = TestClient(app)
 
-gene_ids = ["WB:WBGene00002147", "FB:FBgn0003731"]  # , "SGD:S000003407", "MGI:3588192"]
+gene_ids = ["WB:WBGene00002147", "FB:FBgn0003731", "SGD:S000001049"]  # , "SGD:S000003407", "MGI:3588192"]
 gene_not_found_ids = ["WB:not_real", "FB:fake", "SGD:FAKE", "MGI:MGI:FAKE"]
 logging.basicConfig(filename="combined_access_error.log", level=logging.INFO, format="%(asctime)s - %(message)s")
 logger = logging.getLogger()


### PR DESCRIPTION
For #127, which is to address https://github.com/geneontology/api-gorest-2023/issues/3.

Updates the SPARQL query to additionally fetch metabolic models with the extra criteria: two MF (or molecular event) activity nodes connected by a shared intermediate chemical via `has_input`/`has_output` relations.

The test case gene `SGD:S000001049` ERG11 currently has a [model](http://noctua.geneontology.org/editor/graph/gomodel:YeastPathways_PWY3O-31704?) that satisfies this metabolic criteria so it should return results.

BTW, I just checked and the [switch](https://github.com/alliance-genome/agr_ui/pull/1457) from `.xyz` to the GO API on the Alliance prod site is live. So, once this SPARQL change goes live in the GO API, the Alliance site should be serving up metabolic models.