### PR TITLE
Add GO-CAM index-file entries to production config template (fixes #157)

### DIFF
--- a/provision/templates/config.yaml
+++ b/provision/templates/config.yaml
@@ -5,3 +5,21 @@ ontologies:
   - id: go
     handle: go
     pre_load: false
+gocam_provided_by_index_file:
+    url: "https://current.geneontology.org/go-cams/index-json/provided_by_index.json"
+    timeout: 30
+gocam_contributor_index_file:
+    url: "https://current.geneontology.org/go-cams/index-json/contributor_index.json"
+    timeout: 30
+gocam_taxon_index_file:
+    url: "https://current.geneontology.org/go-cams/index-json/taxon_index.json"
+    timeout: 30
+gocam_entity_index_file:
+    url: "https://current.geneontology.org/go-cams/index-json/entity_index.json"
+    timeout: 30
+gocam_source_index_file:
+    url: "https://current.geneontology.org/go-cams/index-json/source_index.json"
+    timeout: 30
+gocam_evidence_index_file:
+    url: "https://current.geneontology.org/go-cams/index-json/evidence_index.json"
+    timeout: 30


### PR DESCRIPTION
## Problem

Fixes #157.

After the Blazegraph/SPARQL removal (#136), several endpoints read static GO-CAM index JSON files via `app/utils/settings.py::get_index_files()`, keyed off `app/conf/config.yaml`. But the production deploy template `provision/templates/config.yaml` — which `provision/templates/docker-compose-production.yaml` bind-mounts over `/code/app/conf/config.yaml` — only contained `solr_url` and `ontologies`. So a production deploy of `main` would run with a config missing all six `gocam_*_index_file` keys, and `get_index_files()` would raise:

```
ValueError: Configuration key 'gocam_entity_index_file' not found in config.yaml
```

500-ing every index-backed endpoint, including `/gp/{id}/models` (the #135 isoform fix), `/api/taxon/{taxon}/models`, and the source/contributor endpoints.

## Change

Add the six `gocam_*_index_file` blocks to `provision/templates/config.yaml`, mirroring `app/conf/config.yaml` (production `current.geneontology.org` URLs). This makes the deployed config identical to the dev/test default — the minimal, lowest-risk fix.

## Verification

- Template parses as valid YAML (the quoted `{{ solr_url }}` placeholder is a string).
- Index-file keys + URLs now match `app/conf/config.yaml` exactly (parity check: MATCH, none missing).

## Out of scope

- The entity index must actually contain isoform-keyed entries for the isoform fix to return models on `main` — a data/pipeline concern noted in #157, not addressed here.
- `sparqlwrapper` is still a declared dependency and dead SPARQL query-builders remain in `app/utils/ontology_utils.py` (no callers); cleanup can be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_— Posted by Claude Code agent on behalf of @kltm._
