### PR TITLE
Cache GO-CAM index files in-memory (load once per process) (fixes #160)

### DIFF
--- a/app/utils/settings.py
+++ b/app/utils/settings.py
@@ -14,6 +14,7 @@ CONFIG = path.join(path.dirname(path.abspath(__file__)), "../conf/config.yaml")
 golr_config = None
 route_mapping = None
 index_file_overrides = {}
+index_file_cache: dict = {}
 logging.basicConfig(filename="combined_access_error.log", level=logging.INFO, format="%(asctime)s - %(message)s")
 logger = logging.getLogger()
 
@@ -30,54 +31,35 @@ def set_index_file_override(file_key: str, file_path: str):
 
 
 def clear_index_file_overrides():
-    """Clear all index file overrides."""
+    """Clear all index file overrides and any cached index file contents."""
     global index_file_overrides
     index_file_overrides = {}
+    index_file_cache.clear()
 
 
-def get_index_files(file_key: str = None) -> dict:
+def _load_index_file(file_key: str, config: dict) -> dict:
     """
-    Retrieve JSON index file(s) from either a URL or local path.
+    Load a single index file's parsed JSON content, caching it after first load.
 
-    Automatically detects whether the configured path is a URL (http/https) or local file path.
-    For URLs, download the file using the configured timeout.
-    For local paths, read the file directly from disk.
+    A test override (see :func:`set_index_file_override`) always takes precedence and
+    is intentionally never cached, so tests can swap fixture files freely. Otherwise
+    the file is fetched once -- from its configured URL (http/https) or a local path --
+    and the parsed content is held in :data:`index_file_cache` for the lifetime of the
+    process. A given index file is therefore downloaded and parsed at most once;
+    restart the service to pick up regenerated index files.
 
-    :param file_key: The configuration key (e.g., 'gocam_contributor_index_file').
-                     If None, retrieve all index files matching '*_index_file' pattern.
-    :return: If file_key is provided, returns the parsed JSON content.
-             If file_key is None, returns a dict mapping config keys to their JSON content.
+    :param file_key: The configuration key (e.g., 'gocam_entity_index_file').
+    :param config: The parsed config.yaml mapping.
+    :return: The parsed JSON content of the index file.
+    :raises ValueError: If file_key is absent from both overrides and config.
     """
-    global index_file_overrides
-
-    with open(CONFIG, "r") as f:
-        config = yaml.safe_load(f)
-
-    if file_key is None:
-        index_files = {k: v for k, v in config.items() if k.endswith("_index_file")}
-        result = {}
-        for key, file_config in index_files.items():
-            if key in index_file_overrides:
-                with open(index_file_overrides[key], "r") as f:
-                    result[key] = json.load(f)
-                continue
-
-            file_url = file_config["url"]
-            timeout = file_config.get("timeout", 30)
-
-            parsed = urlparse(file_url)
-            if parsed.scheme in ("http", "https"):
-                response = requests.get(file_url, timeout=timeout)
-                response.raise_for_status()
-                result[key] = response.json()
-            else:
-                with open(file_url, "r") as f:
-                    result[key] = json.load(f)
-        return result
-
+    # Test overrides always win and are intentionally not cached.
     if file_key in index_file_overrides:
         with open(index_file_overrides[file_key], "r") as f:
             return json.load(f)
+
+    if file_key in index_file_cache:
+        return index_file_cache[file_key]
 
     if file_key not in config:
         raise ValueError(f"Configuration key '{file_key}' not found in config.yaml")
@@ -90,10 +72,37 @@ def get_index_files(file_key: str = None) -> dict:
     if parsed.scheme in ("http", "https"):
         response = requests.get(file_url, timeout=timeout)
         response.raise_for_status()
-        return response.json()
+        data = response.json()
     else:
         with open(file_url, "r") as f:
-            return json.load(f)
+            data = json.load(f)
+
+    index_file_cache[file_key] = data
+    return data
+
+
+def get_index_files(file_key: str = None) -> dict:
+    """
+    Retrieve JSON index file(s) from either a URL or local path.
+
+    Automatically detects whether the configured path is a URL (http/https) or local
+    file path. For URLs, download the file using the configured timeout; for local
+    paths, read it from disk. Each index file is loaded at most once per process and
+    then served from an in-memory cache, so restart the service to pick up regenerated
+    index files (see :func:`_load_index_file`).
+
+    :param file_key: The configuration key (e.g., 'gocam_contributor_index_file').
+                     If None, retrieve all index files matching '*_index_file' pattern.
+    :return: If file_key is provided, returns the parsed JSON content.
+             If file_key is None, returns a dict mapping config keys to their JSON content.
+    """
+    with open(CONFIG, "r") as f:
+        config = yaml.safe_load(f)
+
+    if file_key is None:
+        return {k: _load_index_file(k, config) for k in config if k.endswith("_index_file")}
+
+    return _load_index_file(file_key, config)
 
 def get_user_agent():
     """Returns the user agent string."""

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -1,0 +1,71 @@
+"""Tests for index-file loading and caching in app.utils.settings."""
+
+import json
+
+import pytest
+
+from app.utils import settings
+from app.utils.settings import (
+    _load_index_file,
+    clear_index_file_overrides,
+    get_index_files,
+    set_index_file_override,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_index_state():
+    """Start and end each test with no overrides and an empty cache."""
+    clear_index_file_overrides()
+    yield
+    clear_index_file_overrides()
+
+
+def test_cached_index_file_served_without_refetch():
+    """A pre-seeded cache entry is returned as-is, without touching the configured URL."""
+    sentinel = {"NCBITaxon:9606": ["model-1"]}
+    settings.index_file_cache["gocam_taxon_index_file"] = sentinel
+    # Served straight from the cache; the http(s) URL in config.yaml is never fetched.
+    assert get_index_files("gocam_taxon_index_file") == sentinel
+    # Identity is preserved across calls -> proves it is cached, not re-parsed each time.
+    assert get_index_files("gocam_taxon_index_file") is sentinel
+
+
+def test_clear_index_file_overrides_empties_cache():
+    """clear_index_file_overrides() also drops cached content (test isolation / reload)."""
+    settings.index_file_cache["gocam_taxon_index_file"] = {"x": []}
+    clear_index_file_overrides()
+    assert settings.index_file_cache == {}
+
+
+def test_override_takes_precedence_over_cache(tmp_path):
+    """A test override must win over any cached content and is itself never cached."""
+    settings.index_file_cache["gocam_taxon_index_file"] = {"CACHED": ["should-not-win"]}
+    override = tmp_path / "taxon.json"
+    override.write_text(json.dumps({"NCBITaxon:7227": ["fly-model"]}))
+    set_index_file_override("gocam_taxon_index_file", str(override))
+
+    assert get_index_files("gocam_taxon_index_file") == {"NCBITaxon:7227": ["fly-model"]}
+    # The override result is not written into the cache.
+    assert settings.index_file_cache["gocam_taxon_index_file"] == {"CACHED": ["should-not-win"]}
+
+
+def test_missing_key_raises_value_error():
+    with pytest.raises(ValueError):
+        get_index_files("gocam_definitely_not_a_real_index_file")
+
+
+def test_local_file_loaded_once_then_cached(tmp_path):
+    """A local-path index file is read once; later edits do not change the cached value."""
+    f = tmp_path / "source.json"
+    f.write_text(json.dumps({"PMID:1": ["m1"]}))
+    config = {"gocam_source_index_file": {"url": str(f)}}
+
+    first = _load_index_file("gocam_source_index_file", config)
+    assert first == {"PMID:1": ["m1"]}
+
+    # Mutating the file on disk must NOT be reflected -> confirms load-once caching.
+    f.write_text(json.dumps({"PMID:1": ["m1"], "PMID:2": ["m2"]}))
+    second = _load_index_file("gocam_source_index_file", config)
+    assert second is first
+    assert second == {"PMID:1": ["m1"]}


### PR DESCRIPTION
## Problem

Fixes #160.

`get_index_files()` (`app/utils/settings.py`) did a fresh `requests.get()` + JSON parse **on every call**, and it's called inside the request handlers (`pathway_widget.py`, `models.py`, `ontology.py`, `users_and_groups.py`) — so every index-backed request re-downloaded and re-parsed the file (`entity_index.json` ≈ 4 MB), blocking the event loop. Nothing cached it anywhere (no decorator, no global, no caching lib, no startup hook). The adjacent `get_golr_config()` already memoizes its config, so this was an oversight from the Blazegraph→index migration.

## Change

Lazy, load-once in-memory cache in `settings.py`:
- New module global `index_file_cache`; each index file is fetched/parsed **at most once per process** and reused thereafter.
- Fetch logic refactored into `_load_index_file(file_key, config)`; `get_index_files()` keeps its public contract (single key, or all `*_index_file` keys when `None`).
- **Test overrides take precedence and are never cached**, so `set_index_file_override()`/`conftest.py` behave exactly as before. `clear_index_file_overrides()` also empties the cache.

### Why lazy-memoize instead of preload-on-startup
- Confined to `settings.py` — no `main.py`/`lifespan` surgery.
- Doesn't couple app boot to CDN availability (a download hiccup at startup won't crash the service; it surfaces on first use, as today).
- Leaves the test-override mechanism untouched (the suite runs entirely through overrides, which bypass the cache).
- Still "load once," and mirrors the existing `get_golr_config()` idiom.

## Operational effect

Regenerated index files are now picked up on a **service restart** (a clean, predictable refresh model) rather than per request. Plenty of RAM headroom — only six small-to-medium files.

## Tests

New `tests/unit/test_settings.py` (functional, no mocks — real file I/O):
- cached entry served without refetch (identity preserved across calls)
- `clear_index_file_overrides()` empties the cache
- override takes precedence over cache and is itself never cached
- missing key raises `ValueError`
- local-path file loaded once then cached (on-disk edits not reflected until clear)

### Validation note
`poetry` is currently broken in my local environment (`ModuleNotFoundError: No module named 'poetry'`) and `app/__init__.py` pulls in `ontobio`, so I could not run the project's full `pytest` locally. I validated the new logic by exercising the real `settings.py` functions directly (module loaded in isolation) with the same assertions as the test file — all five checks pass — plus `py_compile` on both files. CI (`pr-test-qc.yaml`) will run the formal suite. Note CI's `build` check is currently red for the **unrelated** live-data drift tracked in #159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_— Posted by Claude Code agent on behalf of @kltm._
