### PR TITLE
Resolve ribbon aspect roots by GO ID, not GOlr label (fixes #165)

### DIFF
--- a/app/routers/ribbon.py
+++ b/app/routers/ribbon.py
@@ -109,7 +109,9 @@ async def get_ribbon_results(
 
     # Step 1: create the categories
     categories = ontology_utils.get_ontology_subsets_by_id(subset)
-    # in categories
+    # Drop any aspect we couldn't resolve to a root term (no annotation_class) so
+    # a single ontology label drift can't 500 the whole ribbon. See #165.
+    categories = [category for category in categories if category.get("annotation_class")]
     for category in categories:
         category["groups"] = category["terms"]
         del category["terms"]

--- a/app/utils/ontology_utils.py
+++ b/app/utils/ontology_utils.py
@@ -67,6 +67,18 @@ def goont_fetch_label(id):
     return None
 
 
+# The three GO aspect roots, keyed by the GOlr ``source`` value their terms
+# carry. Resolved by stable GO ID rather than by ``annotation_class_label`` so a
+# label change on a root term (e.g. GO:0003674 "molecular_function" ->
+# "gene product or complex activity") cannot drop a category's annotation_class
+# and 500 the ribbon. See geneontology/go-fastapi#165.
+ASPECT_ROOTS = {
+    "molecular_function": "GO:0003674",
+    "biological_process": "GO:0008150",
+    "cellular_component": "GO:0005575",
+}
+
+
 def get_ontology_subsets_by_id(id: str):
     """
     Get ontology subsets based on the provided identifier.
@@ -104,18 +116,24 @@ def get_ontology_subsets_by_id(id: str):
         del ready_term["source"]
         tr[source]["terms"].append(ready_term)
 
-    cats = []
-    for category in tr:
-        cats.append(category)
+    # Resolve each aspect category to its root term by stable GO ID. The second
+    # GOlr query is keyed on annotation_class (the fixed root IDs), not on
+    # annotation_class_label, which drifts when a root term is relabelled.
+    root_ids = [ASPECT_ROOTS[c] for c in tr if c in ASPECT_ROOTS]
+    data = []
+    if root_ids:
+        root_fq = '&fq=annotation_class:("' + '" "'.join(root_ids) + '")&rows=1000'
+        data = gu_run_solr_text_on(ESOLR.GOLR, ESOLRDoc.ONTOLOGY, q, qf, fields, root_fq, False)
 
-    fq = "&fq=annotation_class_label:(" + " or ".join(cats) + ")&rows=1000"
-    data = gu_run_solr_text_on(ESOLR.GOLR, ESOLRDoc.ONTOLOGY, q, qf, fields, fq, False)
-
     for category in tr:
+        root_id = ASPECT_ROOTS.get(category)
+        if root_id is None:
+            # Unknown aspect source: leave annotation_class unset; callers skip it.
+            continue
+        tr[category]["annotation_class"] = root_id
         for temp in data:
-            if temp["annotation_class_label"] == category:
-                tr[category]["annotation_class"] = temp["annotation_class"]
-                tr[category]["description"] = temp["description"]
+            if temp.get("annotation_class") == root_id:
+                tr[category]["description"] = temp.get("description", "")
                 break
 
     result = []
@@ -129,11 +147,11 @@ def get_ontology_subsets_by_id(id: str):
         for agr_category in agr_slim_order:
             cat = agr_category["category"]
             for category in result:
-                if category["annotation_class"] == cat:
+                if category.get("annotation_class") == cat:
                     ordered_terms = []
                     for ordered_term in agr_category["terms"]:
                         for unordered_term in category["terms"]:
-                            if unordered_term["annotation_class"] == ordered_term:
+                            if unordered_term.get("annotation_class") == ordered_term:
                                 ordered_terms.append(unordered_term)
                                 break
                     category["terms"] = ordered_terms

--- a/tests/unit/test_ontology_utils.py
+++ b/tests/unit/test_ontology_utils.py
@@ -219,9 +219,22 @@ class TestOntologyUtils(unittest.TestCase):
         """Test getting subsets of an ontology by ID."""
         ribbon_categories = ou.get_ontology_subsets_by_id("goslim_agr")
         self.assertEqual(len(ribbon_categories), 3)
+        # Every aspect category must resolve to its root GO term. Regression guard
+        # for #165: a root-term relabel in GOlr (e.g. GO:0003674) must not drop the
+        # category's annotation_class, which previously KeyError'd / 500'd the ribbon.
+        resolved = {c.get("annotation_class") for c in ribbon_categories}
+        self.assertEqual(resolved, {"GO:0003674", "GO:0008150", "GO:0005575"})
         for ribbon_category in ribbon_categories:
+            self.assertIsNotNone(ribbon_category.get("annotation_class"))
             if ribbon_category.get("annotation_class") == "GO:0003674":
                 self.assertEqual(len(ribbon_category.get("terms")), 16)
+
+    def test_get_ontology_subsets_by_id_generic(self):
+        """Non-AGR slims also resolve every aspect root by ID (no label round-trip)."""
+        categories = ou.get_ontology_subsets_by_id("goslim_generic")
+        self.assertGreater(len(categories), 0)
+        for category in categories:
+            self.assertIsNotNone(category.get("annotation_class"))
 
     def test_correct_goid(self):
         """Test correcting a GO ID."""


### PR DESCRIPTION
## What

Fixes the ribbon `500` on `subset=goslim_agr` by resolving each aspect category's
root `annotation_class` from a stable `source → GO-ID` map instead of a fragile
`annotation_class_label` round-trip against GOlr.

## Why

`get_ontology_subsets_by_id` grouped slim terms by aspect (`source`) then looked
up each aspect root's GO ID by matching `annotation_class_label == <aspect string>`.
GOlr relabelled the **molecular_function** root `GO:0003674` →
*"gene product or complex activity"*, so that self-join returned nothing for MF,
the category never got an `annotation_class`, and the unguarded reads in the
`goslim_agr` reorder (`ontology_utils.py`) and ribbon Step 1 (`ribbon.py`) raised
`KeyError → 500`. It fires for **every** `goslim_agr` ribbon call (and any subset
spanning molecular_function). Full root-cause in #165.

This is in shared code, so it affects **both** the current `v0.3.x` production
build and `v0.4.0` — rolling the API version does not change it.

## Change (Variant B — minimal blast radius)

- Add `ASPECT_ROOTS = {source → root GO ID}` and resolve `annotation_class` from
  it directly (the three aspect roots are fixed IDs, already hardcoded in
  `agr_slim_order` and ribbon's `aspect_map`).
- Keep one GOlr query, now keyed on `annotation_class` (the root IDs) rather than
  the mutable label — so the per-category `description` on `/api/ontology/subset/{id}`
  is **unchanged** (zero response-shape change). Dropping that query entirely is a
  possible follow-up cleanup, tracked in #166.
- Guard the remaining bare reads (reorder loop + ribbon Step 1) so a single
  ontology label drift can never 500 the whole widget again — unresolved aspects
  are skipped, not fatal.

## Testing

Ran the real pytest harness in a fresh py3.11 venv (via `uv`; CI also uses 3.11)
against **live GOlr** (which currently carries the relabel):

- `tests/unit/test_ontology_utils.py` + `tests/unit/test_ribbon.py` →
  **25 passed, 1 skipped** (the skip is the pre-existing `@unittest.skip` SPARQL
  test). This includes all 14 `goslim_agr` ribbon tests.
- **Before/after proof:** reverting *only* the app code to `main` (keeping the new
  tests) makes `test_ribbon_endpoint` fail with `KeyError` and
  `test_get_ontology_subsets_by_id` fail; the fix turns both green.

Strengthened `test_get_ontology_subsets_by_id` to assert **all three** aspects
resolve to their root IDs (`{GO:0003674, GO:0008150, GO:0005575}`), plus a new
`goslim_generic` case.

## Note on the data

The `GO:0003674` relabel is very likely an unintended GOlr-index change (see #165);
fixing the ontology data is a separate lever. This PR hardens the API so it stays
up regardless.

Fixes #165. See also #166 (follow-up cleanup).

_— Opened by Claude Code agent on behalf of @kltm._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
