### PR TITLE
Fix Alliance fallback for AGR gene_summary API shape (#159 mygene portion)

### DIFF
--- a/app/utils/mygene_utils.py
+++ b/app/utils/mygene_utils.py
@@ -22,23 +22,36 @@ def gene_to_uniprot_from_alliance(gene_id: str) -> list[str]:
         gene_id: A gene identifier (e.g., "HGNC:12139").
 
     Returns:
-        A list of UniProtKB IDs (e.g., ["UniProtKB:A0A5H1ZRN5"]).
+        A list of UniProtKB IDs (e.g., ["UniProtKB:A0A0B4J263"]).
 
     Raises:
         DataNotFoundException: If no UniProtKB cross-references are found.
 
+    Note:
+        AGR restructured this endpoint with no public API versioning or
+        deprecation notice (no ``/api/swagger.json``), which silently broke this
+        lookup. The response is now a ``gene_summary`` document
+        (``{category, searchable, gene}``); UniProtKB cross-references live under
+        ``gene.crossReferences[].referencedCurie`` and the GCRP reference under
+        ``gene.gcrpCrossReference`` -- not the former top-level
+        ``crossReferenceMap.other[].name``. For GCRP-only genes (TR/IG variable
+        segments like TRAV39 / HGNC:12139) the UniProtKB ref was moved out of the
+        general cross-reference list into ``gcrpCrossReference`` by
+        alliance-genome/agr_curation#2713 (2026-05-05), so both must be read.
     """
     url = f"https://www.alliancegenome.org/api/gene/{quote(gene_id, safe='')}"
     response = requests.get(url, timeout=30)
     response.raise_for_status()
-    data = response.json()
+    gene = response.json().get("gene", {}) or {}
 
     uniprot_ids = []
-    cross_refs = data.get("crossReferenceMap", {}).get("other", [])
-    for ref in cross_refs:
-        name = ref.get("name", "")
-        if name.startswith("UniProtKB:"):
-            uniprot_ids.append(name)
+    for ref in gene.get("crossReferences", []) or []:
+        curie = ref.get("referencedCurie", "")
+        if curie.startswith("UniProtKB:"):
+            uniprot_ids.append(curie)
+    gcrp_curie = (gene.get("gcrpCrossReference") or {}).get("referencedCurie", "")
+    if gcrp_curie.startswith("UniProtKB:") and gcrp_curie not in uniprot_ids:
+        uniprot_ids.append(gcrp_curie)
 
     if not uniprot_ids:
         raise DataNotFoundException(detail=f"No UniProtKB IDs found for {gene_id} via Alliance API")

--- a/app/utils/mygene_utils.py
+++ b/app/utils/mygene_utils.py
@@ -38,6 +38,7 @@ def gene_to_uniprot_from_alliance(gene_id: str) -> list[str]:
         segments like TRAV39 / HGNC:12139) the UniProtKB ref was moved out of the
         general cross-reference list into ``gcrpCrossReference`` by
         alliance-genome/agr_curation#2713 (2026-05-05), so both must be read.
+
     """
     url = f"https://www.alliancegenome.org/api/gene/{quote(gene_id, safe='')}"
     response = requests.get(url, timeout=30)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,5 +98,8 @@ max-complexity = 10
 
 [tool.codespell]
 skip = ["*.po","*.ts",".git","pyproject.toml","assert*"]
+# "crossReferences" is a literal AGR API JSON field name, not a typo of
+# "cross-references" (see app/utils/mygene_utils.py).
+ignore-words-list = "crossreferences"
 count = ""
 quiet-level = 3

--- a/tests/unit/test_mygene_utils.py
+++ b/tests/unit/test_mygene_utils.py
@@ -299,6 +299,74 @@ def test_gene_to_uniprot_from_alliance_direct() -> None:
     )
 
 
+def test_alliance_parses_gcrp_only_gene_summary_shape(monkeypatch) -> None:
+    """Lock AGR's gene_summary shape where UniProtKB is in gcrpCrossReference.
+
+    Regression guard for #159: AGR restructured /api/gene/{id} with no public API
+    versioning or deprecation notice (alliance-genome/agr_curation#2713,
+    2026-05-05), moving the GCRP UniProtKB ref out of the general cross-reference
+    list into the dedicated gcrpCrossReference field -- the TR/IG-variable case
+    (TRAV39 / HGNC:12139). Mocked so live data drift can't silently break it again.
+    """
+
+    class _Resp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {
+                "category": "gene_summary",
+                "searchable": False,
+                "gene": {
+                    "crossReferences": [{"referencedCurie": "ENSEMBL:ENSG00000211818"}],
+                    "gcrpCrossReference": {"referencedCurie": "UniProtKB:A0A0B4J263"},
+                },
+            }
+
+    monkeypatch.setattr("app.utils.mygene_utils.requests.get", lambda *a, **k: _Resp())
+
+    assert gene_to_uniprot_from_alliance("HGNC:12139") == ["UniProtKB:A0A0B4J263"]
+
+
+def test_alliance_parses_uniprot_in_cross_references(monkeypatch) -> None:
+    """Lock the other gene_summary branch: UniProtKB in gene.crossReferences[]."""
+
+    class _Resp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {
+                "category": "gene_summary",
+                "gene": {
+                    "crossReferences": [
+                        {"referencedCurie": "UniProtKB:P04637"},
+                        {"referencedCurie": "ENSEMBL:ENSG00000141510"},
+                    ]
+                },
+            }
+
+    monkeypatch.setattr("app.utils.mygene_utils.requests.get", lambda *a, **k: _Resp())
+
+    assert gene_to_uniprot_from_alliance("HGNC:11998") == ["UniProtKB:P04637"]
+
+
+def test_alliance_no_uniprot_raises(monkeypatch) -> None:
+    """No UniProtKB anywhere in the gene_summary -> DataNotFoundException."""
+
+    class _Resp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"category": "gene_summary", "gene": {"crossReferences": []}}
+
+    monkeypatch.setattr("app.utils.mygene_utils.requests.get", lambda *a, **k: _Resp())
+
+    with pytest.raises(DataNotFoundException):
+        gene_to_uniprot_from_alliance("HGNC:99999999")
+
+
 @pytest.mark.integration
 def test_round_trip_gene_to_uniprot_to_gene() -> None:
     """Test round-trip conversion: HGNC -> UniProt -> HGNC.


### PR DESCRIPTION
## What

Fixes the `gene_to_uniprot_from_alliance` fallback after the Alliance of Genome
Resources (AGR) restructured its `GET /api/gene/{id}` response. This clears the 3
`HGNC:12139` mygene/Alliance failures in #159. **The fixture gene is unchanged** —
HGNC:12139 (TRAV39) still resolves; it just moved within the response.

## Why (AGR-side API change, no versioning)

AGR changed the `/api/gene/{id}` schema with **no public API versioning or
deprecation notice** (there's no `…/api/swagger.json`), so this broke silently:

- The response is now a `gene_summary` document — envelope
  `{category, searchable, gene}`.
- UniProtKB cross-references moved to **`gene.crossReferences[].referencedCurie`**
  and **`gene.gcrpCrossReference.referencedCurie`**, replacing the former
  top-level `crossReferenceMap.other[].name` this code read (which no longer
  exists → the helper returned `[]` for every gene).
- For GCRP-only genes (TR/IG variable segments like TRAV39) the UniProtKB ref was
  filtered out of the general cross-reference list into the dedicated
  `gcrpCrossReference` field by
  [alliance-genome/agr_curation#2713](https://github.com/alliance-genome/agr_curation/pull/2713)
  (merged 2026-05-05), after the field was added in
  [#2140](https://github.com/alliance-genome/agr_curation/pull/2140) (2025-07-10).

## Change

- `gene_to_uniprot_from_alliance` now reads `gene.crossReferences[]` **and**
  `gene.gcrpCrossReference` — covering both normal genes (UniProtKB in the general
  list) and GCRP-only genes (UniProtKB only in `gcrpCrossReference`). Docstring
  documents the AGR change + the missing API versioning.
- Adds 3 **deterministic mocked** tests locking the `gene_summary` shape (gcrp-only
  branch, crossReferences branch, and the not-found raise) so a future silent AGR
  schema change can't slip past unit tests again.

## Testing

Full `tests/unit/test_mygene_utils.py` in a py3.11 uv venv (live AGR + mygene):
**25 passed** — including the 3 formerly-red live tests (`HGNC:12139` parametrized,
`test_alliance_fallback_for_hgnc12139`, `test_gene_to_uniprot_from_alliance_direct`)
and the 3 new mocked guards.

## Notes

- Scoped to the **mygene/Alliance `HGNC:12139` portion of #159**; the
  ribbon/`annotation_class` portion is #167.
- Branched off `main` (independent of #167). The full QC suite on this branch will
  still show the ribbon/subset failures until #167 lands; I'll rebase once it
  merges and CI should be fully green.

Addresses #159.

_— Opened by Claude Code agent on behalf of @kltm._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
